### PR TITLE
Excluded fenced code tags from being included in the output

### DIFF
--- a/plugin/tocdown.rb
+++ b/plugin/tocdown.rb
@@ -1,3 +1,4 @@
+insideCodeBlock = false
 headings = IO.readlines(ARGV[0]).collect do |line|
   if line.match(/^((\s){0,3}([`]|[~]){3,})/)
     insideCodeBlock == false ? insideCodeBlock = true : insideCodeBlock = false

--- a/plugin/tocdown.rb
+++ b/plugin/tocdown.rb
@@ -1,5 +1,8 @@
 headings = IO.readlines(ARGV[0]).collect do |line|
-  line.match(/^[#]{1,4}/) ? ("  " * ($&.length - 1) + $'.strip) : nil
+  if line.match(/^((\s){0,3}([`]|[~]){3,})/)
+    insideCodeBlock == false ? insideCodeBlock = true : insideCodeBlock = false
+  end
+  (insideCodeBlock == false and line.match(/^(\s){0,3}[#]{1,4}/)) ? ("  " * ($&.length - 1) + $'.strip) : nil
 end
 
 headings.compact!


### PR DESCRIPTION
I saw that fenced comments showed up in the plugin output. That messes up the TOC in my case. Excluded lines in fenced output from being interpreted as headlines.
I used [CommonMark](http://spec.commonmark.org/0.7/#fenced-code-blocks) as base, but did not go into too much details, e.g. the number of fence-characters is not checked.
